### PR TITLE
Allow BundleAssets to Load from YAML Files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ globset = "0.4.9"
 indexmap = { version = "1.9.1", features = ["serde"] }
 intl-memoizer = "0.5.1"
 ron = "0.7.1"
+serde_yaml = "0.8.24"
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.25"
 unic-langid = { version = "0.9.0", features = ["serde"] }

--- a/examples/minimal/assets/locales/en-US/main.ftl.ron
+++ b/examples/minimal/assets/locales/en-US/main.ftl.ron
@@ -1,6 +1,0 @@
-(
-    locale: "en-US",
-    resources: [
-        "hello_world.ftl",
-    ]
-)

--- a/examples/minimal/assets/locales/en-US/main.ftl.yml
+++ b/examples/minimal/assets/locales/en-US/main.ftl.yml
@@ -1,0 +1,4 @@
+# Locale files may be in YAML as in this example, or in RON
+locale: en-US
+resources:
+  - hello_world.ftl

--- a/examples/minimal/main.rs
+++ b/examples/minimal/main.rs
@@ -23,7 +23,7 @@ fn localized_hello_world(
     assets: Res<Assets<BundleAsset>>,
     mut handle: Local<Option<Handle<BundleAsset>>>,
 ) {
-    let handle = &*handle.get_or_insert_with(|| asset_server.load("locales/en-US/main.ftl.ron"));
+    let handle = &*handle.get_or_insert_with(|| asset_server.load("locales/en-US/main.ftl.yml"));
     if let LoadState::Loaded = asset_server.get_load_state(handle) {
         let bundle = assets.get(handle).unwrap();
         assert!(matches!(bundle.content("hello-world"), Some(content) if content == "hello world"));

--- a/src/assets/bundle.rs
+++ b/src/assets/bundle.rs
@@ -74,7 +74,7 @@ impl AssetLoader for BundleAssetLoader {
             let path = load_context.path().to_string_lossy();
             if path.ends_with(".ron") {
                 load(ron::de::from_bytes(bytes)?, load_context).await
-            } else if path.ends_with(".yaml") || path.ends_with("yml") {
+            } else if path.ends_with(".yaml") || path.ends_with(".yml") {
                 load(serde_yaml::from_slice(bytes)?, load_context).await
             } else {
                 unreachable!("We already check all the supported extensions.");
@@ -83,7 +83,7 @@ impl AssetLoader for BundleAssetLoader {
     }
 
     fn extensions(&self) -> &[&str] {
-        &["ftl.ron", "ftl.yml", "ftl.yaml"]
+        &["ftl.ron", "ftl.yaml", "ftl.yml"]
     }
 }
 


### PR DESCRIPTION
Nice and simple. :)

I switched the minimal example to use YAML as a demonstration, with a comment indicating that YAML or RON could be used.

Do you want another example showing YAML, or do you just want to leave it unchanged and we don't need an example?

Let me know you're preference.