### PR TITLE
Add option to control the insertion of unicode isolation marks when formatting patterns

### DIFF
--- a/src/assets/bundle.rs
+++ b/src/assets/bundle.rs
@@ -69,12 +69,16 @@ impl AssetLoader for BundleAssetLoader {
 #[serde(deny_unknown_fields)]
 struct Data {
     locale: LanguageIdentifier,
+    isolation: Option<bool>,
     resources: Vec<PathBuf>,
 }
 
 #[instrument(fields(path = %load_context.path().display()), skip_all)]
 async fn load(data: Data, load_context: &mut LoadContext<'_>) -> Result<BundleAsset> {
     let mut bundle = FluentBundle::new_concurrent(vec![data.locale.clone()]);
+    if let Some(isolation) = data.isolation {
+        bundle.set_use_isolating(isolation);
+    }
     for mut path in data.resources {
         if path.is_relative() {
             if let Some(parent) = load_context.path().parent() {


### PR DESCRIPTION
This cannot be done in the game code as `FluentBundle` is wrapped in an `Arc` and is immutable. 

The good thing with this approach is that it's entirely optional, so it won't break existing code. It just adds new functionality.

I've tested with a git dependency to my fork and it seems to be working correctly. I couldn't find any tests, so not sure if I should add some.

Let me know if it's okay.

And thanks for the amazing library!