### PR TITLE
Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 exclude = [".github/**/*"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19.0-rc.3", default-features = false, features = [
   "bevy_asset",
   "bevy_log",
 ] }
@@ -37,5 +37,5 @@ unic-langid = { version = "0.9.4", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
-bevy = "0.18"
+bevy = "0.19.0-rc.3"
 unic-langid = { version = "0.9.4", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 exclude = [".github/**/*"]
 
 [dependencies]
-bevy = { version = "0.19.0-rc.3", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
   "bevy_asset",
   "bevy_log",
 ] }
@@ -37,5 +37,5 @@ unic-langid = { version = "0.9.4", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
-bevy = "0.19.0-rc.3"
+bevy = "0.19.0"
 unic-langid = { version = "0.9.4", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ intl-memoizer = "0.5.1"
 ron = "0.12"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_yaml = "0.9.32"
-thiserror = "1.0.58"
+thiserror = "2.0.18"
 tracing = "0.1.40"
 unic-langid = { version = "0.9.4", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["serde", "v4", "v5"] }

--- a/examples/ui/systems/menu.rs
+++ b/examples/ui/systems/menu.rs
@@ -55,8 +55,8 @@ pub fn setup(
                     parent.spawn((
                         Text(choose_language),
                         TextFont {
-                            font: font.0.clone(),
-                            font_size: 64.0,
+                            font: font.0.clone().into(),
+                            font_size: FontSize::Px(64.0),
                             ..default()
                         },
                         TextColor(Color::WHITE),
@@ -92,8 +92,8 @@ pub fn setup(
                             parent.spawn((
                                 Text("<".to_string()),
                                 TextFont {
-                                    font: font.0.clone(),
-                                    font_size: 64.0,
+                                    font: font.0.clone().into(),
+                                    font_size: FontSize::Px(64.0),
                                     ..default()
                                 },
                                 TextColor(Color::WHITE),
@@ -116,8 +116,8 @@ pub fn setup(
                             parent.spawn((
                                 Text(locale),
                                 TextFont {
-                                    font: font.0.clone(),
-                                    font_size: 64.0,
+                                    font: font.0.clone().into(),
+                                    font_size: FontSize::Px(64.0),
                                     ..default()
                                 },
                                 TextColor(Color::WHITE),
@@ -142,8 +142,8 @@ pub fn setup(
                             parent.spawn((
                                 Text(">".to_string()),
                                 TextFont {
-                                    font: font.0.clone(),
-                                    font_size: 64.0,
+                                    font: font.0.clone().into(),
+                                    font_size: FontSize::Px(64.0),
                                     ..default()
                                 },
                                 TextColor(Color::WHITE),

--- a/src/assets/bundle.rs
+++ b/src/assets/bundle.rs
@@ -79,12 +79,7 @@ async fn load(data: Data, load_context: &mut LoadContext<'_>) -> Result<BundleAs
                 path = parent.join(path);
             }
         }
-        let loaded = load_context
-            .loader()
-            .immediate()
-            .with_unknown_type()
-            .load(path)
-            .await?;
+        let loaded = load_context.load_builder().load_untyped_value(path).await?;
         let resource = loaded.get::<ResourceAsset>().unwrap();
         if let Err(errors) = bundle.add_resource(resource.0.clone()) {
             warn_span!("add_resource").in_scope(|| {


### PR DESCRIPTION
- Updated `bevy` version requirement to the most recent 0.19 release candidate.
- Migrated code and examples to work with 0.19.
- Updated `thiserror` version requirement to 2.0.18.